### PR TITLE
タイムゾーンを Tokyo にする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module Gate
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = "Tokyo"
   end
 end


### PR DESCRIPTION
Google Sheets に時刻を記入するとき UTC だとわかりづらかったので！
