### PR TITLE
認証失敗時のメッセージを整える

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,8 @@ class SessionsController < ApplicationController
 
       redirect_to root_path, notice: "こんにちは、#{name}さん！招待しましたのでDiscordアプリをご確認ください"
     else
-      redirect_to root_path, alert: "Discordの登録メールアドレスが、スポンサーのメールアドレス一覧に見つかりませんでした。お手数ですがmail@example.comまで「スポンサー申請時の氏名」「Discordの登録メールアドレス」をご連絡ください。"
+      p [name, email, user_id]
+      redirect_to root_path, alert: "Discordの登録メールアドレスが、スポンサーのメールアドレス一覧に見つかりませんでした。お手数ですが「オンラインコミュニティ招待のお知らせ」に返信する形でご連絡くださいませ。"
     end
   end
 end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -21,7 +21,3 @@
 <%= form_tag("/auth/discord", method: "post", data: { turbo: false }) do %>
   <button type="submit">参加する</button>
 <% end %>
-
-<p>
-  「スポンサー申請時にご入力いただいたメールアドレス」と「Discordの登録メールアドレス」が一致していない場合、お手数ですがmail@example.comまで「スポンサー申請時の氏名」「Discordの登録メールアドレス」をご連絡ください。
-</p>


### PR DESCRIPTION
フリースクール・スポンサーのみなさんに送る案内メールの文言が決まったので、それと Gate の歩調を合わせていきます。

- Gate にはメールアドレスを載せないでおく
  - スパムメール業者にメールアドレスを知られないに越したことはない :see_no_evil:
- なにか困ったら、案内メールに返信する形でお問い合わせしてね、としておく
- 認証失敗時にはログを出力しておく
  - お問い合わせがあったときの調査に使えるように :detective:
