### PR TITLE
有効な招待リンクの一覧を通知する

### DIFF
--- a/app/models/InvitesNotifier.rb
+++ b/app/models/InvitesNotifier.rb
@@ -1,0 +1,29 @@
+class InvitesNotifier
+  def self.notify
+      discord = Discord.new(ENV["DISCORD_BOT_TOKEN"])
+      servers = discord.servers
+      server = servers.find { |s| s["name"] == ENV["DISCORD_SERVER_NAME"] }
+      invites = discord.invites(server["id"]).sort_by { _1["created_at"] }
+      channels = discord.channels(server["id"])
+      channel = channels.find { |c| c["name"] == ENV["DISCORD_SYSTEM_CHANNEL_NAME"] }
+
+      invites.each_slice(50).each do |sub_invites|
+        message =
+          "```" +
+          ["created", "expires", "code", "inviter"].map { _1.ljust(10) }.join("\t") + "\n" +
+          sub_invites.map { |inv|
+            expires_at = inv.dig("expires_at")
+            [
+              inv.dig("created_at").first(10),
+              expires_at ? expires_at.first(10) : "----------",
+              inv.dig("code"),
+              inv.dig("inviter", "global_name"),
+            ].map { _1.ljust(10) }.join("\t")
+          }.join("\n") +
+          "```"
+
+        discord.post_message(channel_id: channel["id"], content: message)
+        sleep 2
+      end
+   end
+end

--- a/lib/discord.rb
+++ b/lib/discord.rb
@@ -24,6 +24,10 @@ class Discord
     JSON.parse(get("/guilds/#{server_id}/channels").body)
   end
 
+  def invites(server_id)
+    JSON.parse(get("/guilds/#{server_id}/invites").body)
+  end
+
   def post_message(channel_id:, content:)
     @connection.post(BASE_PATH + "/channels/#{channel_id}/messages") do |request|
       request.body = { content: content }.to_json


### PR DESCRIPTION
コミュニティの Discord サーバに誰がいつ誰を招待しようとしたか、管理が困難になってきた最近です！それによって Role の付与漏れが起きると、せっかく入ってきてくれた人が快適に過ごせなくなってしまうので、改善をやっていきます。

有効な招待リンクの一覧を通知する処理をつくったので、この内容を運営メンバーズで眺めて「これは、なんの招待？」といった会話につなげていきたいと思います。