### PR TITLE
Productionではconfig.assets.css_compressorをnilにしてみる

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,6 +25,7 @@ Rails.application.configure do
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
+  config.assets.css_compressor = nil
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
これと同じような事象でデプロイに失敗していた。

>Couldn't deploy Rails + Tailwind on Heroku - Stack Overflow
>https://stackoverflow.com/questions/70662382/couldnt-deploy-rails-tailwind-on-heroku

設定を変えたらデプロイ成功するようになったのでこれでいってみよう。
